### PR TITLE
Use exec to prevent creating new process.

### DIFF
--- a/ruby
+++ b/ruby
@@ -82,4 +82,4 @@ elif [ ! -e "$INTERPRETER" ]; then
   exit 124
 fi
 
-$INTERPRETER $FIRST_PARAM "$@"
+exec $INTERPRETER $FIRST_PARAM "$@"


### PR DESCRIPTION
Creating new process might have some side effects, such as changing
PID. Some script might depend on it.

I recently ran into https://github.com/jarib/childprocess/issues/50 due to it. Note that rbenv is also using `exec`, not sure what it could break, but I assume nothing.

[1] https://github.com/sstephenson/rbenv/blob/master/libexec/rbenv-exec#L43
